### PR TITLE
Fix: Remove unused log import causing compilation failure

### DIFF
--- a/internal/services/intelligent_agent_creator.go
+++ b/internal/services/intelligent_agent_creator.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"time"


### PR DESCRIPTION
## Summary
- Remove unused `log` import from `intelligent_agent_creator.go` 
- Fixes compilation error: `"log" imported and not used`

## Test plan
- [x] Verify build completes successfully after fix
- [x] Confirm log package is not used anywhere in the file

🤖 Generated with [Claude Code](https://claude.ai/code)