### PR TITLE
Fix: Expand environment variables in AI API key configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,7 +77,15 @@ func Load() (*Config, error) {
 		cfg.AIModel = viper.GetString("ai_model")
 	}
 	if viper.IsSet("ai_api_key") {
-		cfg.AIAPIKey = viper.GetString("ai_api_key")
+		rawKey := viper.GetString("ai_api_key")
+		// Expand environment variables like ${OPENAI_API_KEY}, but preserve direct values
+		expandedKey := os.ExpandEnv(rawKey)
+		// If expansion resulted in empty string but original had ${}, keep original (missing env var)
+		if expandedKey == "" && rawKey != "" && (len(rawKey) > 3 && rawKey[0] == '$' && rawKey[1] == '{') {
+			cfg.AIAPIKey = rawKey // Keep unexpanded form to show error later
+		} else {
+			cfg.AIAPIKey = expandedKey
+		}
 	}
 	if viper.IsSet("ai_base_url") {
 		cfg.AIBaseURL = viper.GetString("ai_base_url")


### PR DESCRIPTION
## Summary
- Fix environment variable expansion in `ai_api_key` config loading
- Resolves OpenAI 401 errors where `${OPENAI_API_KEY}` wasn't being expanded
- Prevents unintended fallback to Gemini provider

## Changes
- Added `os.ExpandEnv()` to config loading in `/internal/config/config.go`
- Handles both direct API keys (`sk-1234...`) and env vars (`${OPENAI_API_KEY}`)
- Preserves unexpanded form for missing env vars to show better error messages
- Maintains backward compatibility with existing configurations

## Test plan
- [x] Verified agents now use OpenAI correctly (no more 401 errors)  
- [x] Tested with both direct keys and `${ENV_VAR}` syntax
- [x] Station service logs show correct provider initialization
- [x] Build completes successfully

## Before/After
**Before:** `${OPENAI_API_KEY}` sent literally → 401 Unauthorized  
**After:** Environment variable expanded → Successful OpenAI calls

🤖 Generated with [Claude Code](https://claude.ai/code)