### PR TITLE
Fix MCP tool naming consistency across sync, assignment, and execution

### DIFF
--- a/internal/db/migrations/013_create_default_environment.sql
+++ b/internal/db/migrations/013_create_default_environment.sql
@@ -2,11 +2,11 @@
 -- Create a default environment for new Station installations
 
 -- Insert default environment if no environments exist
--- Use the system user (id=0) as the creator
+-- Use the console user as the creator
 INSERT OR IGNORE INTO environments (name, description, created_by, created_at, updated_at)
 SELECT 'default', 
        'Default environment for development and testing',
-       0,
+       (SELECT id FROM users WHERE username = 'console' LIMIT 1),
        datetime('now'),
        datetime('now')
 WHERE NOT EXISTS (SELECT 1 FROM environments);


### PR DESCRIPTION
## Summary
- Fixed critical tool naming inconsistencies preventing agents from accessing MCP tools
- Replaced GenKit MCP integration in sync with pure mcp-go client for real tool discovery
- Updated tool matching logic to handle consistent `__` prefixes properly

## Technical Changes
- **Sync Process**: Now uses mcp-go client to discover real tools with proper `__` prefix
- **Agent Execution**: Updated tool matching to handle double underscore prefixes correctly  
- **Database Migration**: Fixed foreign key constraint preventing successful `stn init`

## End-to-End Verification
✅ Fresh `stn init` works without foreign key errors  
✅ `stn mcp sync` discovers and stores real MCP tools with descriptions  
✅ Agent creation successfully assigns discovered tools  
✅ Agent execution matches assigned tools with runtime tools  
✅ Agents can access and attempt to use MCP tools  

## Before/After
**Before**: Agents showed "No tools available - executing in reasoning-only mode"  
**After**: Agents successfully access MCP tools with "Filtered to 2 assigned tools for agent execution"

Fixes the core tool assignment system that was broken due to naming inconsistencies between sync, storage, and runtime discovery.

🤖 Generated with [Claude Code](https://claude.ai/code)